### PR TITLE
Merging latest official wagtail-autocomplete version into the one forked from rrebase

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.6 Release
+-----------
+
+* Add Wagtail 2.8 support
+
 0.5 Release
 -----------
 

--- a/wagtailautocomplete/__init__.py
+++ b/wagtailautocomplete/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 5)
+VERSION = (0, 6)
 __version__ = '.'.join([str(x) for x in VERSION])

--- a/wagtailautocomplete/urls/admin.py
+++ b/wagtailautocomplete/urls/admin.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url
-from wagtail.admin.decorators import require_admin_access
+try:
+    from wagtail.admin.decorators import require_admin_access
+except ImportError:
+    from wagtail.admin.auth import require_admin_access
 
 from wagtailautocomplete.views import create, objects, search
-
 
 urlpatterns = [
     url(r'^create/', require_admin_access(create)),


### PR DESCRIPTION
It will solve the change in root url issue as well as will be updated.